### PR TITLE
fix(test): make TTL-expiry check deterministic by backdating mtime

### DIFF
--- a/src/xorq_hash_cache/tests/test_hash_cache.py
+++ b/src/xorq_hash_cache/tests/test_hash_cache.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 from pathlib import Path
 
 import pytest
@@ -62,6 +63,11 @@ def test_ttl(tmpdir, ttl, should_be_expired):
     assert get_args_kwargs(f, *args, **kwargs) == hcp.args_kwargs
 
     if should_be_expired:
+        # Backdate the mtime well past the ttl; comparing a freshly-written
+        # mtime against now() is racy for a millisecond ttl.
+        path = hcp.hash_cached.serder.get_path(hcp.stem_path)
+        past = datetime.datetime.now().timestamp() - 3600
+        os.utime(path, (past, past))
         assert hcp.is_expired
         assert g.is_expired(hcp.stem_path)
     else:


### PR DESCRIPTION
`test_ttl`'s `ttl=1ms, should_be_expired=True` case was flaky (~1 in 3): it asserted expiry immediately after the write, but `is_expired` compares elapsed mtime age against the ttl, so if the check ran within 1ms of the write it wasn't expired yet.

Fix: backdate the cached file's mtime one hour into the past (`os.utime`) before asserting, removing the wall-clock race. Production `is_expired` and the `days=1` case are untouched.

Verified: 50/50 runs of `test_ttl` pass; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121paweb8TMuC1ZuN2HH8mk