### PR TITLE
chore: add README, LICENSE, and .gitignore.template

### DIFF
--- a/.gitignore.template
+++ b/.gitignore.template
@@ -1,0 +1,30 @@
+# Copy this file to .gitignore to put it in effect:
+#   cp .gitignore.template .gitignore
+# .gitignore itself is intentionally untracked.
+.gitignore
+
+# Python
+__pycache__/
+*.py[cod]
+*.so
+*.egg-info/
+.eggs/
+build/
+dist/
+
+# Test / lint caches
+.pytest_cache/
+.ruff_cache/
+.coverage
+coverage.xml
+
+# Environments
+.venv/
+.direnv/
+
+# Tooling
+.claude/
+.envrc.secrets
+
+# Runtime cache output
+cache/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,115 @@
+# xorq-hash-cache
+
+A small Python utility for caching function results to disk, keyed by the
+function's identity and the arguments it was called with.
+
+Wrap a function once and every call is transparently memoized to a file on
+disk. Cache entries survive across processes, are keyed by a hash of both the
+function and its arguments, and can optionally expire after a configurable
+time-to-live (TTL).
+
+## Install
+
+```bash
+pip install git+https://github.com/xorq-labs/xorq-hash-cache.git
+```
+
+Or, with [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv add git+https://github.com/xorq-labs/xorq-hash-cache.git
+```
+
+## Quickstart
+
+```python
+from pathlib import Path
+
+from xorq_hash_cache.hash_cache import HashCached
+
+cache_dir = Path("./cache")
+
+
+@HashCached.hash_cache(cache_dir)
+def expensive(x, y):
+    print("computing...")  # only prints on a cache miss
+    return x + y
+
+
+expensive(1, 2)  # computing... -> 3
+expensive(1, 2)  # -> 3  (loaded from disk, no recompute)
+```
+
+Results are serialized with `cloudpickle` by default, so most Python return
+values work out of the box. For JSON-serializable results, use the JSON
+variant, which stores human-readable cache files:
+
+```python
+from xorq_hash_cache.hash_cache import HashCached, calc_kwargs_stem
+
+
+@HashCached.json_hash_cache(cache_dir, calc_stem=calc_kwargs_stem)
+def fetch(item_id, other):
+    return {"item_id": item_id, "other": other}
+```
+
+## Features
+
+- **Persistent, cross-process** — cache entries are plain files under a
+  directory you choose.
+- **Keyed by function + arguments** — the cache path incorporates a hash of the
+  function (via [`xorq-dasher`](https://pypi.org/project/xorq-dasher/)
+  tokenization) and the call's arguments, so changing either yields a new entry.
+- **Pluggable serialization** — pickle (`HashCached.hash_cache`) or JSON
+  (`HashCached.json_hash_cache`) out of the box, or supply your own `Serder`.
+- **Configurable cache keys** — `calc_hash_stem` (default, opaque hash) or
+  `calc_kwargs_stem` (readable `key=value` filenames), or your own.
+- **TTL expiry** — pass `ttl=datetime.timedelta(...)`; expired entries are
+  recomputed on the next call.
+
+## How it works
+
+For a wrapped function `f`, entries are written under:
+
+```
+<path>/<module>.<qualname>/<hash-of-f>/<stem>.pkl
+```
+
+- `<stem>` is derived from the call arguments (`calc_stem`). On a call,
+  `HashCached` computes the stem path, and returns the stored value if it
+  exists and has not expired — otherwise it calls `f`, stores the result, and
+  (for the pickle path) also records the arguments alongside it.
+- The wrapped function exposes the underlying `HashCached` instance as
+  `wrapped.hash_cached`, and `HashCached.gen_hash_cache_paths()` iterates the
+  existing entries (each a `HashCachePath` exposing `.retval`, `.arguments`,
+  and `.is_expired`).
+
+### TTL example
+
+```python
+import datetime
+from xorq_hash_cache.hash_cache import HashCached
+
+hc = HashCached(cache_dir, expensive, ttl=datetime.timedelta(hours=1))
+hc(1, 2)  # cached for one hour, recomputed thereafter
+```
+
+`dated_hash_cache` is also provided, which namespaces the cache under the
+current date (`YYYY-MM-DD`).
+
+## Development
+
+This repo uses [uv](https://docs.astral.sh/uv/) and pre-commit.
+
+```bash
+uv sync --group dev          # install with dev dependencies
+uv run pytest                # run the test suite
+uv run pre-commit run --all-files
+```
+
+CI runs the test suite (Python 3.10 / 3.12 / 3.13) and linting (ruff +
+codespell) on every pull request.
+
+## License
+
+[Apache-2.0](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,8 @@ name = "xorq-hash-cache"
 version = "0.1.0"
 description = "python utility for caching function results"
 readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
     "attrs>=23.0",


### PR DESCRIPTION
Open-source hygiene, kept separate from the CI work in #7.

## Changes
- **`README.md`** — was empty (0 bytes, though `pyproject` points at it). Now documents the `xorq_hash_cache` API: install, quickstart (pickle + JSON variants), features, how-it-works (cache path layout, `HashCachePath`), TTL, and dev/CI notes.
- **`LICENSE`** — the repo had none (legally "all rights reserved"). Added Apache-2.0, copied verbatim from `xorq-labs/xorq` to match the org.
- **`pyproject.toml`** — declares `license = "Apache-2.0"` + `license-files`.
- **`.gitignore.template`** — tracked template following the xorq convention. `.gitignore` itself stays **untracked**; it's on each user to `cp .gitignore.template .gitignore` locally. The template's first line ignores `.gitignore`, and it covers Python/tooling artifacts plus the runtime `cache/` output.

## Verification
Project rebuilds with the new license metadata (`uv sync --locked`), lockfile still valid (`uv lock --check`), and the CI-equivalent checks pass locally: pytest (4 passed), ruff check, ruff format --check, codespell.

## Not included (handled separately)
GitHub repo description and topics are settings, not files — already set via API, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2gj4xTUXYmnBSa8RFerK7