### PR TITLE
test: make pytest import-mode explicit in pyproject

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -38,5 +38,4 @@ jobs:
         timeout-minutes: 10
         run: >
           uv run --no-sync pytest
-          --import-mode=importlib
           -v --durations=20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,7 @@ dev = [
     "pre-commit>=4.2.0",
     "pytest>=8.3.5",
 ]
+
+[tool.pytest.ini_options]
+addopts = "--import-mode=importlib"
+testpaths = ["src"]


### PR DESCRIPTION
Moves pytest discovery config into `pyproject.toml` so it's intentional rather than incidental.

## What
- Add `[tool.pytest.ini_options]` with `addopts = "--import-mode=importlib"` and `testpaths = ["src"]`.
- Drop the now-redundant `--import-mode=importlib` flag from the `ci-test.yml` pytest invocation.

## Why
Previously discovery worked only because the repo root happened to contain no stray test files and CI passed the flag by hand. This makes the behavior explicit and identical whether you run bare `pytest` locally or in CI.

## Verification
`pytest -q` (no CLI flags) → 4 passed; `--collect-only` confirms the 4 tests under `src/` collect in importlib mode. `pre-commit run --all-files` (uv hooks skipped) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2EZMnshp8kiBuSXRVYUhx