### PR TITLE
chore(pre-commit): drop unused uv-export hook, bump uv rev to 0.11.31

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,9 +23,7 @@ repos:
       - id: ruff-format
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.7.3
+    rev: 0.11.31
     hooks:
       # Update the uv lockfile
       - id: uv-lock
-      - id: uv-export
-        args: ["--frozen", "--no-hashes", "--no-emit-project", "--all-groups", "--all-extras", "--output-file=requirements-dev.txt"]


### PR DESCRIPTION
## What
- **Drop the `uv-export` hook.** The only reference to `requirements-dev.txt` anywhere in the tree is the hook that generates it — no CI job, the nix flake, or any tooling consumes it. So it was regenerating a file nobody reads on every commit. `uv-lock` is kept (it genuinely keeps `uv.lock` in sync).
- **Bump `uv-pre-commit` `rev` 0.7.3 → 0.11.31.** The pin was stale (local/CI uv is 0.11.x); this tracks current uv releases.

## Why
`uv-export` churn also forced the awkward `SKIP=uv-lock,uv-export` in `ci-lint.yml` and left `requirements-dev.txt` in limbo (neither committed nor ignored). Removing the hook dissolves that question entirely.

## Verification
- `uv lock --check` passes.
- `pre-commit run uv-lock --all-files` **passes at the new rev 0.11.31**.
- `pre-commit run --all-files` (codespell/ruff/ruff-format) passes; `uv-export` no longer present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2EZMnshp8kiBuSXRVYUhx